### PR TITLE
Fix weird splitline behaviour

### DIFF
--- a/rst2confluence/confluence.py
+++ b/rst2confluence/confluence.py
@@ -150,8 +150,8 @@ class ConfluenceTranslator(nodes.NodeVisitor):
         if self.keepLineBreaks:
             self._add(string)
         else:
-            # rst line break shoud be removed.
-            self._add(" ".join(string.splitlines()))
+            # rst line break should be removed.
+            self._add(" ".join(string.split('\n')))
 
     def visit_emphasis(self, node):
         self._add("_")
@@ -672,3 +672,4 @@ class ConfluenceTranslator(nodes.NodeVisitor):
     #substitution definitions
     def visit_substitution_definition(self, node):
         raise nodes.SkipNode
+

--- a/test/footnote-mixed.rst.exp
+++ b/test/footnote-mixed.rst.exp
@@ -1,4 +1,4 @@
-^2^ will be "2" (manually numbered),^3^ will be "3" (anonymous auto-numbered), and^1^ will be "1" (labeled auto-numbered).
+^2^ will be "2" (manually numbered), ^3^ will be "3" (anonymous auto-numbered), and ^1^ will be "1" (labeled auto-numbered).
 
 bq. ^2^ This footnote is labeled manually, so its number is fixed.
 bq. ^1^ This autonumber-labeled footnote will be labeled "1". It is the first auto-numbered footnote and no other footnote with label "1" exists.  The order of the footnotes is used to determine numbering, not the order of the footnote references.


### PR DESCRIPTION
Splitlines behaves strangely when a line ends with '\n'

```
>>> value = "something\n"
>>> value.splitlines()
['something']
>>> value.split('\n')
['something', '']
```

This has made the program translate this `reStructuredText` input

```
This is something
*new*
```

into this `confluence` output

```
This is something_new_
```

This fix makes it behave normally and make the `confluence` output be

```
This is something _new_
```
