### PR TITLE
Add missing dependencies to setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,6 @@ __ https://pypi.python.org/pypi/rst2confluence
 ============
 Dependencies
 ============
-- ``python-docutils``
 - ``colordiff`` (for running the tests)
 
 =====

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,10 @@ setup(
 
     py_modules=['rst2confluence.confluence'],
     # package_dir={'rst2confluence': 'src/rst2confluence'},
-    scripts=['scripts/rst2confluence']
+    scripts=['scripts/rst2confluence'],
+
+    install_requires=[
+        'docutils',
+        'Pygments',
+    ]
 )


### PR DESCRIPTION
Adds docutils and Pygments to the dependencies in setup.py.

docutils is required by the confluence.py module and Pygments
is used for code block syntax highlighting in documents.